### PR TITLE
ci: release pipeline checkout git submodule

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,8 @@ jobs:
       - create-release
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Docker image
         run: echo "v${{ needs.versioning.outputs.version }}"


### PR DESCRIPTION
When building the docker image it's necessary to checkout the git submodules.