### PR TITLE
fox: SOAP share response types

### DIFF
--- a/app/src/main/java/gateway/soap/request/ShareWithReq.java
+++ b/app/src/main/java/gateway/soap/request/ShareWithReq.java
@@ -5,5 +5,5 @@ import java.util.UUID;
 public class ShareWithReq extends Operation
 {
 	public UUID fileUUID;
-	public UUID otherUserUUID;
+	public String otherUsername;
 }

--- a/app/src/main/java/gateway/soap/request/UnShareWithReq.java
+++ b/app/src/main/java/gateway/soap/request/UnShareWithReq.java
@@ -5,5 +5,5 @@ import java.util.UUID;
 public class UnShareWithReq
 {
 	public UUID fileUUID;
-	public UUID otherUserUUID;
+	public String otherUsername;
 }

--- a/app/src/main/java/gateway/soap/response/SharedFile.java
+++ b/app/src/main/java/gateway/soap/response/SharedFile.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 public class SharedFile
 {
+	public String name;
 	public UUID fileUUID;
 	public String ownerUsername;
 	public Boolean is_file;

--- a/app/src/main/java/gateway/soap/response/SharedFile.java
+++ b/app/src/main/java/gateway/soap/response/SharedFile.java
@@ -1,12 +1,6 @@
 package gateway.soap.response;
 
-import java.util.UUID;
-
-public class SharedFile
+public class SharedFile extends File
 {
-	public String name;
-	public UUID fileUUID;
 	public String ownerUsername;
-	public Boolean is_file;
-	public int size;
 }


### PR DESCRIPTION
- Add file name in `SharedFile` response type for `listSharedWithMe` request.
- Use username instead of user UUID for identifying users in `shareWith` and `unShareWith`.