### PR TITLE
docs: SOAP OpenAPI specification

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -4,9 +4,9 @@ This document describes how to use the service as a CLI tool.
 
 ## Environment variables
 
-| Variable                 | Description                 | Example      |
-|--------------------------|-----------------------------|--------------|
-| `AUTHENTICATION_BASEURL` | Authentication service host | `172.18.0.1` |
-| `METADATA_BASEURL`       | Metadata service host       | `172.18.0.1` |
-| `WORKER_HOST`            | Worker service host         | `172.18.0.1` |
-| `WORKER_PORT`            | Worker service RMI port     | `1099`       |
+| Variable                 | Description                 | Example                 |
+|--------------------------|-----------------------------|-------------------------|
+| `AUTHENTICATION_BASEURL` | Authentication service host | `http://127.0.0.1:8081` |
+| `METADATA_BASEURL`       | Metadata service host       | `http://127.0.0.1:8082` |
+| `WORKER_HOST`            | Worker service host         | `127.0.0.1`             |
+| `WORKER_PORT`            | Worker service RMI port     | `1099`                  |

--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@ Microservice to expose main CapyFile services.
 
 ## Documentation
 
-| Document                | URL                                                                                |
-|-------------------------|------------------------------------------------------------------------------------|
-| CLI documentation       | [CLI.md](CLI.md)                                                                   |
-| CICD                    | [CICD.md](https://github.com/hawks-atlanta/docs/blob/main/CICD.md)                 |
-| CONTRIBUTING            | [CONTRIBUTING.md](https://github.com/hawks-atlanta/docs/blob/main/CONTRIBUTING.md) |
-| SOAP service definition | [Service.java](app/src/main/java/gateway/soap/Service.java)                        |
+| Document                    | URL                                                                                |
+|-----------------------------|------------------------------------------------------------------------------------|
+| CLI documentation           | [CLI.md](CLI.md)                                                                   |
+| CICD                        | [CICD.md](https://github.com/hawks-atlanta/docs/blob/main/CICD.md)                 |
+| CONTRIBUTING                | [CONTRIBUTING.md](https://github.com/hawks-atlanta/docs/blob/main/CONTRIBUTING.md) |
+| SOAP Java interfaces        | [Service.java](app/src/main/java/gateway/soap/Service.java)                        |
+| SOAP service API definition | [Specification](docs/spec.openapi.yml)                                             |
 
 ## Development
 

--- a/app/src/main/java/gateway/App.java
+++ b/app/src/main/java/gateway/App.java
@@ -1,12 +1,7 @@
 package gateway;
 
-import capyfile.rmi.interfaces.*;
 import gateway.config.Config;
-import gateway.soap.*;
-import java.rmi.NotBoundException;
-import java.rmi.RemoteException;
-import java.rmi.registry.LocateRegistry;
-import java.rmi.registry.Registry;
+import gateway.soap.ServiceImp;
 import javax.xml.ws.Endpoint;
 
 public class App
@@ -16,33 +11,9 @@ public class App
 		// init config from env vars
 		Config.initializeFromEnv ();
 
-		// consume RMI
-		try {
-			// get service
-
-			System.out.println ("Gateway: RMI demo");
-			Registry registry =
-				LocateRegistry.getRegistry (Config.getWorkerHost (), Config.getWorkerPort ());
-			IWorkerService server = (IWorkerService)registry.lookup ("WorkerService");
-
-			// TODO: Replace me
-			// example
-
-			File queryUpload = new File ("----", null);
-			server.uploadFile (queryUpload);
-
-			FileDownload queryDownload = new FileDownload ("----");
-			File resultFile = server.downloadFile (queryDownload);
-
-			System.out.println ("Successfully communicated with worker RMI");
-
-		} catch (Exception e) {
-			System.err.println (e);
-		}
-
+		// serve SOAP
 		System.out.println ("Gateway: Starting SOAP");
 
-		// serve SOAP
 		Endpoint.publish ("http://0.0.0.0:8080/service", new ServiceImp ());
 	}
 }

--- a/app/src/main/java/gateway/soap/Service.java
+++ b/app/src/main/java/gateway/soap/Service.java
@@ -39,7 +39,7 @@ public interface Service {
 
 	@WebMethod ResStatus share_file (ReqShareFile args);
 
-	@WebMethod ResStatus share_remove (ReqShareRemove args);
+	@WebMethod ResStatus unshare_file (ReqShareRemove args);
 
 	@WebMethod ResShareList share_list (Authorization auth);
 

--- a/app/src/main/java/gateway/soap/Service.java
+++ b/app/src/main/java/gateway/soap/Service.java
@@ -9,33 +9,39 @@ import javax.jws.WebService;
 public interface Service {
 	// auth
 
-	@WebMethod SessionRes login (Credentials credentials);
+	@WebMethod ResSession auth_login (Credentials credentials);
 
-	@WebMethod SessionRes register(Credentials credentials);
+	@WebMethod ResSession auth_refresh (Authorization auth);
 
-	@WebMethod StatusRes updatePassword (UpdatePasswordReq parameters);
+	// account
+
+	@WebMethod ResSession account_register (Credentials credentials);
+
+	@WebMethod ResStatus account_password (ReqAccPassword parameters);
 
 	// file system
 
-	@WebMethod StatusRes createFile (CreateFileReq args);
+	@WebMethod ResFileList file_list (ReqFileList args);
 
-	@WebMethod StatusRes createDirectory (CreateDirectoryReq args);
+	@WebMethod ResFileNew file_upload (ReqFileUpload args);
 
-	@WebMethod StatusRes deleteFile (DeleteFileReq args);
+	@WebMethod ResFileNew file_new_dir (ReqFileNewDir args);
 
-	@WebMethod ListFileRes listFiles (ListFileReq args);
+	@WebMethod ResFileCheck file_check (ReqFile args);
 
-	@WebMethod DownloadFileRes downloadFile (DownloadFileReq args);
+	@WebMethod ResStatus file_delete (ReqFileDelete args);
 
-	@WebMethod StatusRes moveFile (MoveFileReq args);
+	@WebMethod ResFileDownload file_download (ReqFile args);
+
+	@WebMethod ResStatus file_move (ReqFileMove args);
 
 	// sharing
 
-	@WebMethod StatusRes shareWith (ShareWithReq args);
+	@WebMethod ResStatus share_file (ReqShareFile args);
 
-	@WebMethod StatusRes unShareWith (UnShareWithReq args);
+	@WebMethod ResStatus share_remove (ReqShareRemove args);
 
-	@WebMethod SharedWithWhoRes sharedWithWho (SharedWithWhoReq args);
+	@WebMethod ResShareList share_list (Authorization auth);
 
-	@WebMethod ListSharedWithMeRes listSharedWithMe (Authorization auth);
+	@WebMethod ResShareListWithWho share_list_with_who (ReqFile args);
 }

--- a/app/src/main/java/gateway/soap/ServiceImp.java
+++ b/app/src/main/java/gateway/soap/ServiceImp.java
@@ -160,7 +160,7 @@ import org.json.JSONObject;
 
 	@WebMethod public ResStatus share_file (ReqShareFile args) { return null; }
 
-	@WebMethod public ResStatus share_remove (ReqShareRemove args) { return null; }
+	@WebMethod public ResStatus unshare_file (ReqShareRemove args) { return null; }
 
 	@WebMethod public ResShareList share_list (Authorization auth) { return null; }
 

--- a/app/src/main/java/gateway/soap/ServiceImp.java
+++ b/app/src/main/java/gateway/soap/ServiceImp.java
@@ -60,13 +60,13 @@ import org.json.JSONObject;
 				// If the status code is 201, indicating login succeed, initialize an Authorization
 				// object in the response and extract the JWT token.
 				res.auth = new Authorization ();
-				res.success = true;
+				res.error = false;
 				res.auth.token = jsonObject.getString ("jwt");
 			} else {
 				// If the status code is different from 201, indicating an error response, extract
 				// success status and message from the JSON object.
-				res.success = jsonObject.getBoolean ("succeed");
-				res.message = jsonObject.getString ("msg");
+				res.error = true;
+				res.msg = jsonObject.getString ("msg");
 			}
 
 		} catch (IOException | InterruptedException e) {
@@ -112,11 +112,11 @@ import org.json.JSONObject;
 
 			if (statusCode == 201) {
 				res.auth = new Authorization ();
-				res.success = true;
+				res.error = false;
 				res.auth.token = jsonObject.getString ("jwt");
 			} else {
-				res.success = jsonObject.getBoolean ("succeed");
-				res.message = jsonObject.getString ("msg");
+				res.error = true;
+				res.msg = jsonObject.getString ("msg");
 			}
 
 		} catch (IOException | InterruptedException e) {
@@ -139,8 +139,8 @@ import org.json.JSONObject;
 		System.out.println (args.fileName);
 		System.out.println ("---");
 		ResStatus s = new ResStatus ();
-		s.success = true;
-		s.message = "File created successfully";
+		s.error = false;
+		s.msg = "File created successfully";
 		return (ResFileNew)s;
 	}
 

--- a/app/src/main/java/gateway/soap/ServiceImp.java
+++ b/app/src/main/java/gateway/soap/ServiceImp.java
@@ -17,10 +17,10 @@ import org.json.JSONObject;
 {
 	// auth
 
-	@WebMethod public SessionRes login (Credentials credentials)
+	@WebMethod public ResSession auth_login (Credentials credentials)
 	{
-		// Create a new SessionRes object to hold the response data
-		SessionRes res = new SessionRes ();
+		// Create a new ResSession object to hold the response data
+		ResSession res = new ResSession ();
 
 		// Define the URL for the authentication request
 		String url = Config.getAuthBaseUrl () + "/login";
@@ -78,10 +78,12 @@ import org.json.JSONObject;
 		return res;
 	}
 
+	@WebMethod public ResSession auth_refresh (Authorization auth) { return null; }
+
 	// user register in auth service, returns an access token
-	@WebMethod public SessionRes register(Credentials credentials)
+	@WebMethod public ResSession account_register (Credentials credentials)
 	{
-		SessionRes res = new SessionRes ();
+		ResSession res = new ResSession ();
 
 		String url = Config.getAuthBaseUrl () + "/register";
 
@@ -124,14 +126,11 @@ import org.json.JSONObject;
 		return res;
 	}
 
-	@WebMethod public StatusRes updatePassword (UpdatePasswordReq parameters)
-	{
-		return new StatusRes ();
-	}
+	@WebMethod public ResStatus account_password (ReqAccPassword parameters) { return null; }
 
 	// file system
 
-	@WebMethod public StatusRes createFile (CreateFileReq args)
+	@WebMethod public ResFileNew file_upload (ReqFileUpload args)
 	{
 		// TODO: Replace me
 		System.out.println ("---");
@@ -139,32 +138,31 @@ import org.json.JSONObject;
 		System.out.println (args.token);
 		System.out.println (args.fileName);
 		System.out.println ("---");
-		StatusRes s = new StatusRes ();
+		ResStatus s = new ResStatus ();
 		s.success = true;
 		s.message = "File created successfully";
-		return s;
+		return (ResFileNew)s;
 	}
 
-	@WebMethod public StatusRes createDirectory (CreateDirectoryReq args)
-	{
-		return new StatusRes ();
-	}
+	@WebMethod public ResFileNew file_new_dir (ReqFileNewDir args) { return null; }
 
-	@WebMethod public StatusRes deleteFile (DeleteFileReq args) { return new StatusRes (); }
+	@WebMethod public ResFileCheck file_check (ReqFile args) { return null; }
 
-	@WebMethod public ListFileRes listFiles (ListFileReq args) { return null; }
+	@WebMethod public ResStatus file_delete (ReqFileDelete args) { return null; }
 
-	@WebMethod public DownloadFileRes downloadFile (DownloadFileReq args) { return null; }
+	@WebMethod public ResFileList file_list (ReqFileList args) { return null; }
 
-	@WebMethod public StatusRes moveFile (MoveFileReq args) { return new StatusRes (); }
+	@WebMethod public ResFileDownload file_download (ReqFile args) { return null; }
+
+	@WebMethod public ResStatus file_move (ReqFileMove args) { return null; }
 
 	// sharing
 
-	@WebMethod public StatusRes shareWith (ShareWithReq args) { return new StatusRes (); }
+	@WebMethod public ResStatus share_file (ReqShareFile args) { return null; }
 
-	@WebMethod public StatusRes unShareWith (UnShareWithReq args) { return new StatusRes (); }
+	@WebMethod public ResStatus share_remove (ReqShareRemove args) { return null; }
 
-	@WebMethod public SharedWithWhoRes sharedWithWho (SharedWithWhoReq args) { return null; }
+	@WebMethod public ResShareList share_list (Authorization auth) { return null; }
 
-	@WebMethod public ListSharedWithMeRes listSharedWithMe (Authorization auth) { return null; }
+	@WebMethod public ResShareListWithWho share_list_with_who (ReqFile args) { return null; }
 }

--- a/app/src/main/java/gateway/soap/request/DownloadFileReq.java
+++ b/app/src/main/java/gateway/soap/request/DownloadFileReq.java
@@ -1,8 +1,0 @@
-package gateway.soap.request;
-
-import java.util.UUID;
-
-public class DownloadFileReq extends Operation
-{
-	public UUID fileUUID;
-}

--- a/app/src/main/java/gateway/soap/request/Operation.java
+++ b/app/src/main/java/gateway/soap/request/Operation.java
@@ -1,6 +1,0 @@
-package gateway.soap.request;
-
-public class Operation extends Authorization
-{
-	// TODO: Add additional fields
-}

--- a/app/src/main/java/gateway/soap/request/ReqAccPassword.java
+++ b/app/src/main/java/gateway/soap/request/ReqAccPassword.java
@@ -1,0 +1,7 @@
+package gateway.soap.request;
+
+public class ReqAccPassword extends Authorization
+{
+	public String oldpassword;
+	public String newpassword;
+}

--- a/app/src/main/java/gateway/soap/request/ReqFile.java
+++ b/app/src/main/java/gateway/soap/request/ReqFile.java
@@ -2,8 +2,7 @@ package gateway.soap.request;
 
 import java.util.UUID;
 
-public class ShareWithReq extends Operation
+public class ReqFile extends Authorization
 {
 	public UUID fileUUID;
-	public String otherUsername;
 }

--- a/app/src/main/java/gateway/soap/request/ReqFileDelete.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileDelete.java
@@ -2,7 +2,7 @@ package gateway.soap.request;
 
 import java.util.UUID;
 
-public class DeleteFileReq extends Operation
+public class ReqFileDelete extends Authorization
 {
 	public UUID[] fileUUID; // 1+
 }

--- a/app/src/main/java/gateway/soap/request/ReqFileList.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileList.java
@@ -2,7 +2,7 @@ package gateway.soap.request;
 
 import java.util.UUID;
 
-public class ListFileReq extends Operation
+public class ReqFileList extends Authorization
 {
 	public UUID location;
 }

--- a/app/src/main/java/gateway/soap/request/ReqFileMove.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileMove.java
@@ -1,0 +1,10 @@
+package gateway.soap.request;
+
+import java.util.UUID;
+
+public class ReqFileMove extends Authorization
+{
+	public UUID fileUUID;
+	public UUID targetDirectoryUUID; // always a directory
+	public String newName;			 // optional
+}

--- a/app/src/main/java/gateway/soap/request/ReqFileNewDir.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileNewDir.java
@@ -2,7 +2,7 @@ package gateway.soap.request;
 
 import java.util.UUID;
 
-public class CreateDirectoryReq extends Operation
+public class ReqFileNewDir extends Authorization
 {
 	public String directoryName;
 	public UUID location;

--- a/app/src/main/java/gateway/soap/request/ReqFileUpload.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileUpload.java
@@ -2,9 +2,9 @@ package gateway.soap.request;
 
 import java.util.UUID;
 
-public class CreateFileReq extends Operation
+public class ReqFileUpload extends Authorization
 {
 	public String fileName;
-	public Byte[] fileContent;
+	public byte[] fileContent;
 	public UUID location;
 }

--- a/app/src/main/java/gateway/soap/request/ReqRenameFile.java
+++ b/app/src/main/java/gateway/soap/request/ReqRenameFile.java
@@ -2,7 +2,7 @@ package gateway.soap.request;
 
 import java.util.UUID;
 
-public class MoveFileReq extends Operation
+public class ReqRenameFile extends Authorization
 {
 	public UUID nameUUID;
 	public UUID targetLocationUUID; // always a directory

--- a/app/src/main/java/gateway/soap/request/ReqShareFile.java
+++ b/app/src/main/java/gateway/soap/request/ReqShareFile.java
@@ -2,7 +2,7 @@ package gateway.soap.request;
 
 import java.util.UUID;
 
-public class UnShareWithReq
+public class ReqShareFile extends Authorization
 {
 	public UUID fileUUID;
 	public String otherUsername;

--- a/app/src/main/java/gateway/soap/request/ReqShareRemove.java
+++ b/app/src/main/java/gateway/soap/request/ReqShareRemove.java
@@ -2,7 +2,8 @@ package gateway.soap.request;
 
 import java.util.UUID;
 
-public class SharedWithWhoReq extends Operation
+public class ReqShareRemove
 {
 	public UUID fileUUID;
+	public String otherUsername;
 }

--- a/app/src/main/java/gateway/soap/request/UpdatePasswordReq.java
+++ b/app/src/main/java/gateway/soap/request/UpdatePasswordReq.java
@@ -1,8 +1,0 @@
-package gateway.soap.request;
-
-public class UpdatePasswordReq
-{
-	public String token;
-	public String newpass;
-	public String oldpass;
-}

--- a/app/src/main/java/gateway/soap/response/DownloadFileRes.java
+++ b/app/src/main/java/gateway/soap/response/DownloadFileRes.java
@@ -1,7 +1,0 @@
-package gateway.soap.response;
-
-public class DownloadFileRes extends StatusRes
-{
-	public String fileName;
-	public Byte[] fileContent;
-}

--- a/app/src/main/java/gateway/soap/response/ResFileCheck.java
+++ b/app/src/main/java/gateway/soap/response/ResFileCheck.java
@@ -1,0 +1,6 @@
+package gateway.soap.response;
+
+public class ResFileCheck extends ResStatus
+{
+	public boolean ready;
+}

--- a/app/src/main/java/gateway/soap/response/ResFileDownload.java
+++ b/app/src/main/java/gateway/soap/response/ResFileDownload.java
@@ -1,0 +1,7 @@
+package gateway.soap.response;
+
+public class ResFileDownload extends ResStatus
+{
+	public String fileName;
+	public byte[] fileContent;
+}

--- a/app/src/main/java/gateway/soap/response/ResFileList.java
+++ b/app/src/main/java/gateway/soap/response/ResFileList.java
@@ -1,6 +1,6 @@
 package gateway.soap.response;
 
-public class ListFileRes extends StatusRes
+public class ResFileList extends ResStatus
 {
 	public File[] files;
 }

--- a/app/src/main/java/gateway/soap/response/ResFileNew.java
+++ b/app/src/main/java/gateway/soap/response/ResFileNew.java
@@ -1,0 +1,8 @@
+package gateway.soap.response;
+
+import java.util.UUID;
+
+public class ResFileNew extends ResStatus
+{
+	public UUID fileUUID;
+}

--- a/app/src/main/java/gateway/soap/response/ResSession.java
+++ b/app/src/main/java/gateway/soap/response/ResSession.java
@@ -2,7 +2,7 @@ package gateway.soap.response;
 
 import gateway.soap.request.Authorization;
 
-public class SessionRes extends StatusRes
+public class ResSession extends ResStatus
 {
 	public Authorization auth;
 }

--- a/app/src/main/java/gateway/soap/response/ResShareList.java
+++ b/app/src/main/java/gateway/soap/response/ResShareList.java
@@ -1,6 +1,6 @@
 package gateway.soap.response;
 
-public class ListSharedWithMeRes extends StatusRes
+public class ResShareList extends ResStatus
 {
 	public SharedFile[] sharedFiles;
 }

--- a/app/src/main/java/gateway/soap/response/ResShareListWithWho.java
+++ b/app/src/main/java/gateway/soap/response/ResShareListWithWho.java
@@ -1,6 +1,6 @@
 package gateway.soap.response;
 
-public class SharedWithWhoRes extends StatusRes
+public class ResShareListWithWho extends ResStatus
 {
 	public String[] usernames;
 }

--- a/app/src/main/java/gateway/soap/response/ResStatus.java
+++ b/app/src/main/java/gateway/soap/response/ResStatus.java
@@ -1,6 +1,6 @@
 package gateway.soap.response;
 
-public class StatusRes
+public class ResStatus
 {
 	public boolean success = false;
 	public String message = "";

--- a/app/src/main/java/gateway/soap/response/ResStatus.java
+++ b/app/src/main/java/gateway/soap/response/ResStatus.java
@@ -2,6 +2,6 @@ package gateway.soap.response;
 
 public class ResStatus
 {
-	public boolean success = false;
-	public String message = "";
+	public boolean error = true;
+	public String msg = "";
 }

--- a/docs/spec.openapi.yml
+++ b/docs/spec.openapi.yml
@@ -71,7 +71,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResSession'
         'default':
-          description: An error occurred, see other codes at [Authentication API Spec](https://github.com/hawks-atlanta/authentication-go/blob/main/docs/spec.openapi.yaml)
+          description: An error occurred, see other codes at [Authentication API Spec `POST /challenge`](https://github.com/hawks-atlanta/authentication-go/blob/main/docs/spec.openapi.yaml)
           content:
             Object:
               schema:
@@ -336,7 +336,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResStatus'
 
-  /share_remove:
+  /unshare_file:
     post:
       tags:
         - Share

--- a/docs/spec.openapi.yml
+++ b/docs/spec.openapi.yml
@@ -1,0 +1,658 @@
+openapi: 3.0.3
+
+info:
+  title: Capyfile Gateway Service
+
+  license:
+    name: MIT
+    url: https://github.com/hawks-atlanta/gateway-java/blob/main/LICENSE
+
+  version: TBA
+  
+  description: |
+    Describes requests exposed in the gateway SOAP service. Despite it not being a REST API this specification was created for developers convenience, so that they don't have to deal with the WSDL file. This document is for reference only.
+    
+    How to read this document:
+    - Endpoints → SOAP requests
+    - Response codes → ResStatus code field
+
+tags:
+  - name: Auth
+  - name: Account
+  - name: File
+  - name: Share
+
+paths:
+
+  # authorization / authentication
+  
+  /auth_login:
+    post:
+      tags:
+        - Auth
+      description: Authenticates to the server
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/Credentials'
+      responses:
+        '200':
+          description: Login succeeded
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResSession'
+        'default':
+          description: An error occurred, see other codes at [Authentication API Spec](https://github.com/hawks-atlanta/authentication-go/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+
+                
+  /auth_refresh:
+    post:
+      tags:
+        - Auth
+      security:
+        - bearerAuth: []
+      description: Returns a new token
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/Authorization'
+      responses:
+        '200':
+          description: Refresh succeeded
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResSession'
+        'default':
+          description: An error occurred, see other codes at [Authentication API Spec](https://github.com/hawks-atlanta/authentication-go/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+
+  # account
+                
+  /account_register:
+    post:
+      tags:
+        - Account
+      description: Creates a new account
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/Credentials'
+      responses:
+        '200':
+          description: Register succeeded
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResSession'
+        'default':
+          description: An error occurred, see other codes at [Authentication API Spec](https://github.com/hawks-atlanta/authentication-go/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+                
+  /account_password:
+    patch:
+      security:
+        - bearerAuth: []
+      tags:
+        - Account
+      description: Updates the user's password
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/ReqAccPassword'
+      responses:
+        '200':
+          description: Password updated successfully
+          content:
+            object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+        'default':
+          description: An error occurred, see other codes at [Authentication API Spec](https://github.com/hawks-atlanta/authentication-go/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+
+  # file system
+
+  /file_list:
+    post:
+      tags: ["File"]
+      description: List files in a given directory. List the user's root directory when the location field is Null.
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/ReqFileList'
+      responses:
+        "200":
+          description: Ok. The directory was listed.
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResFileList'
+        'default':
+          description: An error occurred, error code and message returned. See possible responses at [Metadata API Spec](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+                
+  /file_upload:
+    post:
+      tags:
+        - File
+      description: Stores a new file in the given location UUID and registers it in the user account. The file is not immediately uploaded so you can check it's state later with the `/file_check` request.
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/ReqFileUpload'
+      responses:
+        "200":
+          description: File is being uploaded. You can check it's state later with the `/file_check` request.
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResFileNew'
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint `POST /files`](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+                
+  /file_new_directory:
+    post:
+      tags:
+        - File
+      description: Creates a new directory in the given location UUID.
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/ReqFileNewDir'
+      responses:
+        "200":
+          description: Directory created.
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResFileNew'
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint `POST /File`](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+
+  /file_check:
+    post:
+      tags:
+        - File
+      description: Returns a boolean value describing whether an uploaded file is ready or not, i.e. fully written in storage.
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/ReqFile'
+      responses:
+        "200":
+          description: Ok, checking completed, and result returned.
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResFileCheck'
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+                
+  /file_download:
+    post:
+      tags:
+        - File
+      description: Return the byte contents of a stored file.
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/ReqFile'
+      responses:
+        "200":
+          description: Ok. Contents returned.
+          content:
+            object:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ResFileDownload"
+        "500":
+          description: Internal server error
+          content:
+            object:
+              schema:
+                $ref: "#/components/schemas/ResStatus"
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint `GET /files/metadata/{file_uuid}`](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+
+  /file_delete:
+    post:
+      tags: ["File"]
+      description: Delete one or multiple files from the user account.
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/ReqFileDelete'
+      responses:
+        "200":
+          description: The file was deleted.
+          content:
+            object:
+              schema:
+                $ref: "#/components/schemas/ResStatus"
+        "500":
+          description: Internal server error
+          content:
+            object:
+              schema:
+                $ref: "#/components/schemas/ResStatus"
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint `DELETE /files/{user_uuid}/{file_uuid}`](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+                
+  /file_move:
+    put:
+      tags: ["File"]
+      description: Move or rename the given file. If `targetDirectoryUUID` is provided the file will be moved. If `newName` is provided the name will be renamed. 
+      requestBody:
+        content:
+          Object:
+            schema:
+              $ref: '#/components/schemas/ReqFileMove'
+      responses:
+        "200":
+          description: The file was moved / renamed.
+          content:
+            object:
+              schema:
+                $ref: "#/components/schemas/ResStatus"
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint `PUT /files/rename/{user_uuid}/{file_uuid}` and `PUT /files/move/{user_uuid}/{file_uuid}`](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+
+  # share
+
+  /share_file:
+    post:
+      tags:
+        - Share
+      description: Share the given file with the given user
+      requestBody:
+        content:
+          object:
+            schema:
+              $ref: "#/components/schemas/ReqShareFile"
+      responses:
+        "200":
+          description: The file was shared
+          content:
+            object:
+              schema:
+                $ref: "#/components/schemas/ResStatus"
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint `POST /files/share/{user_uuid}/{file_uuid}`](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+
+  /share_remove:
+    post:
+      tags:
+        - Share
+      description: Unshare the given file with the given user
+      requestBody:
+        content:
+          object:
+            schema:
+              $ref: "#/components/schemas/ReqShareRemove"
+      responses:
+        "200":
+          description: The file was unshared
+          content:
+            object:
+              schema:
+                $ref: "#/components/schemas/ResStatus"
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint `POST /files/unshare/{user_uuid}/{file_uuid}`](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+
+  /share_list:
+    post:
+      tags:
+        - Share
+      description: List the files that have been shared with this account (you).
+      requestBody:
+        content:
+          object:
+            schema:
+              $ref: "#/components/schemas/Authorization"
+      responses:
+        "200":
+          description: Ok. List returned.
+          content:
+            object:
+              schema:
+                $ref: "#/components/schemas/ResShareList"
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint `GET /files/shared_with_me/{user_uuid}`](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+                
+  /share_list_with_who:
+    post:
+      tags:
+        - Share
+      description: List the users which this file has been shared with.
+      requestBody:
+        content:
+          object:
+            schema:
+              $ref: "#/components/schemas/ReqFile"
+      responses:
+        "200":
+          description: The list of usernames of the users which the file was shared is returned.
+          content:
+            object:
+              schema:
+                $ref: "#/components/schemas/ResShareListWithWho"
+        'default':
+          description: An error occurred. Returns error code and message. See possible responses at [Metadata API Spec endpoint `GET /files/shared_with_who/{file_uuid}`](https://github.com/hawks-atlanta/metadata-scala/blob/main/docs/spec.openapi.yaml)
+          content:
+            Object:
+              schema:
+                $ref: '#/components/schemas/ResStatus'
+
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  schemas:
+  
+    # Base types
+    
+    Authorization:
+      type: object
+      properties:
+        token:
+          type: string
+          example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxMjM0NTY3ODkwIiwidXVpZCI6IjY0MTg1NjZmLWNhMDgtNGI0Ny1iMzQzLWNkNjliNDU0OGYwNyJ9.P45Rr8IfPKCwinKKceRjD0Syeygoa_9R6RsWkXFy4sU
+
+    ResStatus:
+      type: object
+      properties:
+        code:
+          type: number
+          example: 200
+        error:
+          type: boolean
+          example: false
+        msg:
+          type: string
+          example: ""
+
+    ResSession:
+      allOf:
+        - type: object
+          properties:
+            auth:
+              $ref: '#/components/schemas/Authorization'
+        - $ref: '#/components/schemas/ResStatus'
+          
+    Credentials:
+      type: object
+      properties:
+        username:
+          type: string
+        password:
+          type: string
+          
+    # account types
+    
+    ReqAccPassword:
+      allOf:
+        - type: object
+          properties:
+            oldpassword:
+              type: string
+            newpassword:
+              type: string
+        - $ref: '#/components/schemas/Authorization'
+     
+    # file types
+    
+    File:
+      type: object
+      properties:
+        name:
+          type: string
+          example: picture.png
+        isFile:
+          type: boolean
+        uuid:
+          type: string
+          example: 5295d524-aafc-407c-96ed-adae2cd5047a
+        size:
+          type: number
+          example: 46350
+    
+    ReqFileList:
+      allOf:
+        - type: object
+          properties:
+            location:
+              type: string
+              example: 5295d524-aafc-407c-96ed-adae2cd5047a
+        - $ref: '#/components/schemas/Authorization'
+    
+    ResFileList:
+      allOf:
+        - type: object
+          properties:
+            files:
+              type: array
+              items:
+                $ref: '#/components/schemas/File'
+        - $ref: '#/components/schemas/ResStatus'
+    
+    ReqFileUpload:
+      allOf:
+        - type: object
+          properties:
+            fileName:
+              type: string
+              example: picture.png
+            fileContent:
+              type: array
+              items:
+                type: number
+              example: byte[]
+            location:
+              type: string
+              example: 5295d524-aafc-407c-96ed-adae2cd5047a
+        - $ref: '#/components/schemas/Authorization'
+    
+    ReqFileNewDir:
+      allOf:
+        - type: object
+          properties:
+            directoryName:
+              type: string
+              example: my_secret_folder
+            location:
+              type: string
+              example: 5295d524-aafc-407c-96ed-adae2cd5047a
+        - $ref: '#/components/schemas/Authorization'
+    
+    ResFileNew:
+      allOf:
+        - type: object
+          properties:
+            fileUUID:
+              type: string
+              example: 5295d524-aafc-407c-96ed-adae2cd5047a
+        - $ref: '#/components/schemas/ResStatus'
+    
+    ResFileCheck:
+      allOf:
+        - type: object
+          properties:
+            ready:
+              type: boolean
+        - $ref: '#/components/schemas/ResStatus'
+      
+    ReqFileDelete:
+      allOf:
+        - type: object
+          properties:
+            fileUUID:
+              type: array
+              items:
+                type: string
+                example: 5295d524-aafc-407c-96ed-adae2cd5047a
+        - $ref: '#/components/schemas/Authorization'
+    
+    ResFileDownload:
+      allOf:
+        - type: object
+          properties:
+            fileName:
+              type: string
+              example: picture.png
+            fileContent:
+              type: array
+              items:
+                type: number
+              example: []
+        - $ref: '#/components/schemas/ResStatus'
+    
+    ReqFileMove:
+      allOf:
+        - type: object
+          required:
+            - fileUUID
+            - token
+          properties:
+            fileUUID:
+              type: string
+              example: 5295d524-aafc-407c-96ed-adae2cd5047a
+            targetDirectoryUUID:
+              type: string
+              example: 5295d524-aafc-407c-96ed-adae2cd5047a
+            newName:
+              type: string
+              example: picture_new_name.png
+        - $ref: '#/components/schemas/Authorization'
+        
+    # share types
+  
+    SharedFile:
+      allOf:
+        - type: object
+          properties:
+            ownerUsername:
+              type: string
+              example: CocoTheCat
+        - $ref: '#/components/schemas/File'
+          
+    ReqShareFile:
+      allOf:
+        - type: object
+          properties:
+            fileUUID:
+              type: string
+              example: 5295d524-aafc-407c-96ed-adae2cd5047a
+            otherUsername:
+              type: string
+              example: whosthenert67
+        - $ref: '#/components/schemas/Authorization'
+        
+    ReqShareRemove:
+      allOf:
+        - type: object
+          properties:
+            fileUUID:
+              type: string
+              example: 5295d524-aafc-407c-96ed-adae2cd5047a
+            otherUsername:
+              type: string
+              example: whosthenert67
+        - $ref: '#/components/schemas/Authorization'
+    
+    ResShareList:
+      allOf:
+        - type: object
+          properties:
+            sharedFiles:
+              type: array
+              items:
+                $ref: '#/components/schemas/SharedFile'
+        - $ref: '#/components/schemas/ResStatus'
+        
+    ReqFile:
+      allOf:
+        - type: object
+          properties:
+            fileUUID:
+              type: string
+              example: 5295d524-aafc-407c-96ed-adae2cd5047a
+        - $ref: '#/components/schemas/Authorization'
+        
+    ResShareListWithWho:
+      allOf:
+        - type: object
+          properties:
+            usernames:
+              type: array
+              items:
+                type: string
+                example: Hubert Cumberdale
+        - $ref: '#/components/schemas/ResStatus'

--- a/soap-python-client.py
+++ b/soap-python-client.py
@@ -10,31 +10,16 @@ from zeep import Client
 client = Client('http://localhost:8080/service?wsdl')
 
 # consume methods
-result = client.service.register({
+result = client.service.account_register({
             'username':  'woynert',
             'password': 'password'
             })
 
 print(result)
 
-result = client.service.login({
+result = client.service.auth_login({
             'username':  'woynert',
             'password': 'password'
             })
 
-print(result)
-
-result = client.service.login({
-            'username':  'woynert2',
-            'password': 'password'
-            })
-
-print(result)
-
-result = client.service.createFile({
-                'token': 'my-token',
-                'fileName': 'notwoynert',
-                'fileContent':  [],
-                'location': '164dcb6e-7dd7-45ea-bab7-96829307f084'
-            })
 print(result)


### PR DESCRIPTION
**What's added:**
- [OpenAPI specification added](https://github.com/hawks-atlanta/gateway-java/blob/c6a06c5731500d727fb6f713761341a48f27669f/docs/spec.openapi.yml).
- Standardize and update soap type names.
- Updated `CLI.md` and `README.md`
- Remove RMI sample code from App.java

## `docs/spec.openapi.yml`

Describes requests exposed in the gateway SOAP service. Despite this service not being a REST API this specification was created for developers convenience, so that they don't have to deal with the WSDL file.

How to read:

- Endpoints → SOAP requests
- Response codes → ResStatus code field
