### PR TITLE
fix: Update field validation

### DIFF
--- a/app/src/main/java/gateway/controller/CtrlFileUpload.java
+++ b/app/src/main/java/gateway/controller/CtrlFileUpload.java
@@ -32,7 +32,7 @@ public class CtrlFileUpload
 		if (args.fileContent.length == 0) {
 			s.code = 400;
 			s.error = true;
-			s.msg = "{\"fileContent: must not be empty\"}";
+			s.msg = "\"fileContent must not be empty\"";
 			return s;
 		} else if (args.fileContent.length > Config.MAX_FILE_SIZE) {
 			s.code = 413; // payload too large

--- a/app/src/main/java/gateway/services/UtilValidator.java
+++ b/app/src/main/java/gateway/services/UtilValidator.java
@@ -14,15 +14,13 @@ public class UtilValidator
 			Validation.buildDefaultValidatorFactory ().getValidator ().validate (obj);
 
 		if (val.size () > 0) {
-			s.msg += "{";
 			for (ConstraintViolation<T> violation : val) {
 				s.msg += String.format (
-					"\"%s: %s\",", violation.getPropertyPath ().toString (),
+					"\"%s %s\",", violation.getPropertyPath ().toString (),
 					violation.getMessage ());
 			}
-			s.msg = s.msg.substring (0, s.msg.length () - 1);
-			s.msg += "}";
 
+			s.msg = s.msg.substring (0, s.msg.length () - 1);
 			s.code = 400;
 			s.error = true;
 			return s;

--- a/app/src/main/java/gateway/soap/request/Credentials.java
+++ b/app/src/main/java/gateway/soap/request/Credentials.java
@@ -1,11 +1,11 @@
 package gateway.soap.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 
 public class Credentials
 {
-	@NotNull public String username;
-	@NotNull public String password;
+	@NotEmpty public String username;
+	@NotEmpty public String password;
 
 	public Credentials () {}
 	public Credentials (String username, String password)

--- a/app/src/main/java/gateway/soap/request/ReqAccPassword.java
+++ b/app/src/main/java/gateway/soap/request/ReqAccPassword.java
@@ -1,9 +1,10 @@
 package gateway.soap.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 public class ReqAccPassword extends Authorization
 {
 	@NotNull public String oldpassword;
-	@NotNull public String newpassword;
+	@NotEmpty public String newpassword;
 }

--- a/app/src/main/java/gateway/soap/request/ReqFileDelete.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileDelete.java
@@ -1,8 +1,9 @@
 package gateway.soap.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public class ReqFileDelete extends Authorization
 {
-	public UUID[] fileUUID; // 1+
+	@NotNull public UUID[] fileUUID; // 1+
 }

--- a/app/src/main/java/gateway/soap/request/ReqFileMove.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileMove.java
@@ -1,9 +1,10 @@
 package gateway.soap.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public class ReqFileMove extends Authorization
 {
-	public UUID fileUUID;
+	@NotNull public UUID fileUUID;
 	public UUID targetDirectoryUUID; // always a directory
 }

--- a/app/src/main/java/gateway/soap/request/ReqFileNewDir.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileNewDir.java
@@ -1,10 +1,10 @@
 package gateway.soap.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.UUID;
 
 public class ReqFileNewDir extends Authorization
 {
-	@NotNull public String directoryName;
+	@NotEmpty public String directoryName;
 	public UUID location;
 }

--- a/app/src/main/java/gateway/soap/request/ReqFileRename.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileRename.java
@@ -1,10 +1,11 @@
 package gateway.soap.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public class ReqFileRename extends Authorization
 {
 	@NotNull public UUID fileUUID;
-	@NotNull public String newName;
+	@NotEmpty public String newName;
 }

--- a/app/src/main/java/gateway/soap/request/ReqFileUpload.java
+++ b/app/src/main/java/gateway/soap/request/ReqFileUpload.java
@@ -1,13 +1,12 @@
 package gateway.soap.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public class ReqFileUpload extends Authorization
 {
-	@NotNull public String fileName;
-
+	@NotEmpty public String fileName;
 	@NotNull public byte[] fileContent;
-
 	public UUID location;
 }

--- a/app/src/main/java/gateway/soap/request/ReqShareFile.java
+++ b/app/src/main/java/gateway/soap/request/ReqShareFile.java
@@ -1,10 +1,11 @@
 package gateway.soap.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public class ReqShareFile extends Authorization
 {
 	@NotNull public UUID fileUUID;
-	@NotNull public String otherUsername;
+	@NotEmpty public String otherUsername;
 }

--- a/app/src/main/java/gateway/soap/request/ReqShareRemove.java
+++ b/app/src/main/java/gateway/soap/request/ReqShareRemove.java
@@ -1,9 +1,11 @@
 package gateway.soap.request;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public class ReqShareRemove
 {
-	public UUID fileUUID;
-	public String otherUsername;
+	@NotNull public UUID fileUUID;
+	@NotEmpty public String otherUsername;
 }


### PR DESCRIPTION
## Includes:
- Improve some field validations with the use of `@NotEmpty`
- Simplify field validator error messages:

  from
  
  ```
  '{"fileContent: must not be null","fileName: must not be empty"}'
  ```
  to
  
  ```
  "fileContent must not be null","fileName must not be empty"
  ```